### PR TITLE
Add method for creating immutable DTOs

### DIFF
--- a/src/Faithlife.Reflection/DtoInfo.cs
+++ b/src/Faithlife.Reflection/DtoInfo.cs
@@ -112,6 +112,7 @@ namespace Faithlife.Reflection
 		/// Creates a new instance of the DTO.
 		/// </summary>
 		/// <param name="argsAndProps">A collection of DTO constructor arguments and mutable DTO properties/fields with which to create and populate the new DTO instance.</param>
+		/// <exception cref="ArgumentException">No combination of constructor and mutable properties/fields is compatible with the passed items.</exception>
 		[return: NotNull]
 		public T CreateNew(IEnumerable<(string Name, object? Value)> argsAndProps)
 		{
@@ -161,7 +162,7 @@ namespace Faithlife.Reflection
 				}
 				catch (MissingMethodException)
 				{
-					throw new ArgumentException($"No combination of '{typeof(T).Name}' constructor and mutable properties is compatible with the passed items.");
+					throw new ArgumentException($"No combination of '{typeof(T).Name}' constructor and mutable properties/fields is compatible with the passed items.");
 				}
 			}
 		}

--- a/src/Faithlife.Reflection/IDtoInfo.cs
+++ b/src/Faithlife.Reflection/IDtoInfo.cs
@@ -37,6 +37,12 @@ namespace Faithlife.Reflection
 		object CreateNew();
 
 		/// <summary>
+		/// Creates a new instance of the DTO from a collection of properties.
+		/// </summary>
+		/// <param name="argsAndProps">A collection of DTO constructor arguments and mutable DTO properties/fields with which to create and populate the new DTO instance.</param>
+		object CreateNew(IEnumerable<(string Name, object? Value)> argsAndProps);
+
+		/// <summary>
 		/// Clones the specified DTO by copying each property into a new instance.
 		/// </summary>
 		/// <param name="value">The instance to clone.</param>

--- a/src/Faithlife.Reflection/IDtoInfo.cs
+++ b/src/Faithlife.Reflection/IDtoInfo.cs
@@ -40,6 +40,7 @@ namespace Faithlife.Reflection
 		/// Creates a new instance of the DTO from a collection of properties.
 		/// </summary>
 		/// <param name="argsAndProps">A collection of DTO constructor arguments and mutable DTO properties/fields with which to create and populate the new DTO instance.</param>
+		/// <exception cref="ArgumentException">No combination of constructor and mutable properties/fields is compatible with the passed items.</exception>
 		object CreateNew(IEnumerable<(string Name, object? Value)> argsAndProps);
 
 		/// <summary>


### PR DESCRIPTION
How's this look to close #4? To summarize, this `CreateNew` method first uses [`InvokeMember`](https://docs.microsoft.com/en-us/dotnet/api/system.type.invokemember?view=netcore-3.1#System_Type_InvokeMember_System_String_System_Reflection_BindingFlags_System_Reflection_Binder_System_Object_System_Object___System_Reflection_ParameterModifier___System_Globalization_CultureInfo_System_String___) to try and find a constructor that takes _all_ of the passed items. If it doesn't find one, it'll separate out all the items with names and types that match those of mutable properties/fields of the DTO type, then look for a constructor that takes the remaining items, and if it's successful, it'll set the mutable props/fields manually after creating the instance.

I named the parameter `argsAndProps` instead of `properties` when I realized that constructor arguments could have different names from the immutable properties they set, but I can switch back to `properties` or something else if it would look nicer. I just can't think of a way to target the immutable property names directly since the abstraction of a constructor method conceals which arguments affect which immutable properties.

I was pleasantly surprised to find that the [`DefaultBinder`](https://docs.microsoft.com/en-us/dotnet/api/system.type.defaultbinder?view=netcore-3.1) already matches named parameters in a case-insensitive manner, so I didn't have to write a new `Binder`. 👍🏼

Would adding an `IDtoInfo.Constructors` still be useful? I wrote most of a `DtoConstructor` class (inspired by `DtoProperty`) before I realized that I didn't need it if I used `InvokeMember`, so I could finish that up if it'd be handy.