### PR TITLE
Set package license locally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
     <NoWarn>$(NoWarn);1591;1998;CA1515;CA2263;NU1507;NU5105</NoWarn>
     <GitHubOrganization>Faithlife</GitHubOrganization>
     <RepositoryName>FaithlifeReflection</RepositoryName>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <!-- DO NOT EDIT: dotnet-common-props convention -->


### PR DESCRIPTION
## Summary
- set PackageLicenseExpression in the repository-owned Directory.Build.props property group
- preserve the MIT package license after dotnet-common-props stops managing it

## Testing
- Parsed Directory.Build.props as XML
- Ran git diff --check